### PR TITLE
bump BSON dep to support Node 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/punkave/mongo-dump-stream",
   "dependencies": {
     "async": "^0.9.0",
-    "bson": "^0.2.19",
+    "bson": "^0.4.22",
     "buffertools": "^2.1.2",
     "lodash": "^3.3.1",
     "mongodb": "^1.4.32",


### PR DESCRIPTION
otherwise, you'll get the error:

```
js-bson: Failed to load c++ bson extension, using pure JS version
```
